### PR TITLE
Necesario mantener la funcion ucfirst en los dos returns

### DIFF
--- a/src/FieldBuilder.php
+++ b/src/FieldBuilder.php
@@ -535,7 +535,7 @@ class FieldBuilder
         $label = $this->lang->get($attribute);
 
         if ($label == $attribute) {
-            return str_replace(['_', '.'], ' ', $name);
+            return ucfirst(str_replace(['_', '.'], ' ', $name));
         }
 
         return ucfirst($label);


### PR DESCRIPTION
Había quitado la función ucfirst de el segundo return, pero me e dado cuenta que es necesario mantenerla en los dos return.