### PR TITLE
Corrects the persistence of alert messages in session for Laravel 5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Install by running `composer require "styde/html=~1.0"` or adding `"styde/html":
 ],
 ```
 
-3. Also, you need to register in the `app/Http/Kernel.php` file the `\Styde\Html\Alert\Middleware::class` middleware **BEFORE** the `EncryptCookies` middleware. For Laravel 5.4 and later, it's in the `$middlewareGroups` array and for previous versions (Laravel 5.3, 5.2, 5.1) it's in the `$middleware` array:
+3. Also, you need to register in the `app/Http/Kernel.php` file the `\Styde\Html\Alert\Middleware::class` middleware **BEFORE** the `EncryptCookies` middleware, for Laravel 5.8 and later the middleware needs to be registered **AFTER** the `StartSession` middleware. For Laravel 5.4 and later, it's in the `$middlewareGroups` array and for previous versions (Laravel 5.3, 5.2, 5.1) it's in the `$middleware` array:
 
 ```php
 // For Laravel 5.4 and later
 protected $middlewareGroups = [
+    // For Laravel 5.8 and later this needs to be after the StartSession middleware
     \Styde\Html\Alert\Middleware::class,
     //...
 ];

--- a/src/Alert/Middleware.php
+++ b/src/Alert/Middleware.php
@@ -21,8 +21,9 @@ class Middleware {
     }
 
     /**
-     * This is just a requisite of the framework's middleware.
-     * We are not doing anything special here.
+     * Call the push method of the Alert Container object, which will get the
+     * messages in array format (raw), and persist them using the Alert Handler
+     * implementation.
      *
      * @param $request
      * @param \Closure $next
@@ -30,20 +31,11 @@ class Middleware {
      */
     public function handle($request, \Closure $next)
     {
-        return $next($request);
-    }
+        $response = $next($request);
 
-    /**
-     * Call the push method of the Alert Container object, which will get the
-     * messages in array format (raw), and persist them using the Alert Handler
-     * implementation.
-     *
-     * @param $request
-     * @param $response
-     */
-    public function terminate($request, $response)
-    {
         $this->alert->push();
+
+        return $response;
     }
 
 }


### PR DESCRIPTION
Due to this change https://github.com/laravel/framework/pull/26410 the persistence of the session has moved   from `StartSession::terminate` to `StartSession::handle`, so if the alert messages are pushed to the session in `Styde\Html\Alert\Middleware::terminate` they will be pushed to the session but never will be saved to the persistence layer of the session because the session will be saved before.

This PR  moves the push of the alert messages to `Styde\Html\Alert\Middleware::handle` to remediate this problem. **But it's also necessary to register the `Alert` middleware AFTER the `StartSession` middleware** to push the messages to the session before the session is saved in `StartSession` 