### PR TITLE
Let publish resources independently using groups

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -43,13 +43,13 @@ class HtmlServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../themes', 'styde.html');
 
-        $this->publishes([
-            __DIR__.'/../themes' => base_path('resources/views/themes'),
-        ]);
+        $this->publishes(
+            [__DIR__.'/../themes' => base_path('resources/views/themes')], 'styde-html-themes'
+        );
 
-        $this->publishes([
-            __DIR__.'/../config.php' => config_path('html.php'),
-        ]);
+        $this->publishes(
+            [__DIR__.'/../config.php' => config_path('html.php')], 'styde-html-config'
+        );
     }
 
     protected function mergeDefaultConfiguration()


### PR DESCRIPTION
The default `php artisan vendor:publish --provider='Styde\Html\HtmlServiceProvider'` will still work and publish both resources. Adding these groups we could filter using the `--tag` option which resource we want to publish.